### PR TITLE
feat(issue-23): Add SecureMessaging module

### DIFF
--- a/Groupie.toc
+++ b/Groupie.toc
@@ -14,3 +14,4 @@ Globals.lua
 Core.lua
 RightClick.lua
 Listener.lua
+Modules/SecureMessaging.lua

--- a/Modules/SecureMessaging.lua
+++ b/Modules/SecureMessaging.lua
@@ -1,0 +1,64 @@
+local addonName, addon = ...
+
+local COLOR = {
+    RED = "FFFF0000",
+}
+
+local SecureMessaging = {
+    verified={},
+    ADDON_PREFIX="Groupie.SM",
+    WHISPER_MATCHES={
+        [1]="groupie:",
+    },
+    WARNING_MESSAGE="the following message was not sent by Groupie"
+};
+
+function SecureMessaging:SendSecureMessage(message, chatType, target)
+    C_ChatInfo.SendAddonMessage(SecureMessaging.ADDON_PREFIX, message, chatType, target);
+end
+
+-- Use this for sending secure messages. It will send the message as per regular SendChatMessage, but will also send a prior addon message to verify the message.
+function SecureMessaging:SendChatMessage(message, chatType, target)
+    self:SendSecureMessage(message, chatType, target);
+    SendChatMessage(message, chatType, nil, target);
+end
+
+function SecureMessaging:IsGroupiePrefix(prefix)
+    return prefix == SecureMessaging.ADDON_PREFIX;
+end
+
+function SecureMessaging:IsGroupieWhisper(message)
+    message = message:lower();
+    for _, match in ipairs(self.WHISPER_MATCHES) do
+        if message:find(match) then
+            return true;
+        end
+    end
+    return false;
+end
+
+function SecureMessaging.PLAYER_ENTERING_WORLD(event, isLogin, isReload)
+    if isLogin or isReload then
+        C_ChatInfo.RegisterAddonMessagePrefix(SecureMessaging.ADDON_PREFIX);
+    end
+end
+
+function SecureMessaging.CHAT_MSG_ADDON(prefix, message, ...)
+    if SecureMessaging:IsGroupiePrefix(prefix) then
+        SecureMessaging.verified[message] = true;
+    end
+end
+
+function SecureMessaging.CHAT_MSG_WHISPER(message)
+    if SecureMessaging:IsGroupieWhisper(message) then
+        if not SecureMessaging.verified[message] then
+            print(WrapTextInColorCode("Groupie:", COLOR.RED), WrapTextInColorCode(SecureMessaging.WARNING_MESSAGE, COLOR.RED));
+        end
+    end
+end
+
+addon:RegisterEvent("CHAT_MSG_WHISPER", SecureMessaging.CHAT_MSG_WHISPER);
+addon:RegisterEvent("PLAYER_ENTERING_WORLD", SecureMessaging.PLAYER_ENTERING_WORLD);
+addon:RegisterEvent("CHAT_MSG_ADDON", SecureMessaging.CHAT_MSG_ADDON);
+
+addon.SM = SecureMessaging;


### PR DESCRIPTION
Addresses #23 implementation
- for sending secure messages, use `addon.SM:SendChatMessage(message, chatType, target)` as per comment